### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,4 +1,6 @@
 name: Build Linux Packages
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -44,6 +46,8 @@ jobs:
 
   upload_to_release:
     name: Upload Packages to GitHub Release
+    permissions:
+      contents: write
     needs: [build_rpm, build_deb, build_tar, build_appimage]
     if: ${{ github.event.inputs.upload_to_latest_release == 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Shieldowskyy/PiozaLauncher/security/code-scanning/8](https://github.com/Shieldowskyy/PiozaLauncher/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow. The best approach is to set the default permissions at the workflow level to `contents: read` (the most restrictive reasonable default), and then override the permissions for the `upload_to_release` job to grant `contents: write` (since it uploads assets to a release). This ensures that only the job that needs write access to releases has it, and all other jobs have minimal permissions. The changes should be made at the top of the workflow file (for the global default) and within the `upload_to_release` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
