### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -1,4 +1,6 @@
 name: Build Installer
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Shieldowskyy/PiozaLauncher/security/code-scanning/10](https://github.com/Shieldowskyy/PiozaLauncher/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. The best way is to add `permissions: contents: read` at the top level of the workflow (just after the `name` and before `on`), which will apply to all jobs in the workflow. This ensures the workflow only has read access to repository contents, adhering to the principle of least privilege. No changes to the steps or jobs are required, and no additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
